### PR TITLE
#13115 file manager propagates selected file to the rest of the backend

### DIFF
--- a/application/core/constants.py
+++ b/application/core/constants.py
@@ -38,7 +38,8 @@ class FileConstants:
     MARKDOWN_EXTENSIONS = ['.md', '.markdown']
     MAX_FILE_SIZE_MB = 50
     ENCODING_UTF8 = 'utf-8'
-    
+    ENCODING_CP1252 = 'cp1252'
+
     # File dialog filters
     MARKDOWN_FILTER = "Markdown Files (*.md *.markdown);;All Files (*)"
     

--- a/application/core/file_manager.py
+++ b/application/core/file_manager.py
@@ -47,6 +47,7 @@ class FileManager:
         self.file_helper = file_helper
         self.auto_stager = auto_stager
         self.current_file_path: Optional[str] = None
+        self.current_file_content: Optional[str] = None
         self._is_loading_file = False
         self._is_dirty = False
         self.template_loader = template_loader
@@ -74,24 +75,30 @@ class FileManager:
         self._is_loading_file = True
         try:
             content = self.file_helper.read_file(validated)
+            if content is None:
+                self.tab_manager.set_error("Cannot analyze - failed to read file content.")
+                return
+
             self.tab_manager.load_file_into_tab(validated, content)
             
             self.current_file_path = validated
+            self.current_file_content = content
             self._is_dirty = False
             self.tab_manager.set_active_tab_file(validated)
             self.tab_manager.set_tab_dirty(False)
-            self._analyze_current_file(validated)
+            self._analyze_current_file(validated, content)
         except Exception:
             self.tab_manager.set_error("Cannot analyze - failed to load file in viewer.")
         finally:
             self._is_loading_file = False
 
-    def _analyze_current_file(self, file_path: str) -> None:
+    def _analyze_current_file(self, file_path: str, content: str) -> None:
         """Analyze the currently loaded markdown file and update the analysis panel.
 
         Args:
             file_path: Path to the markdown file to analyze. The file is assumed
                 to already be loaded into the viewer.
+            content: In-memory markdown content supplied by FileManager.
 
         Returns:
             None. Updates analysis panel with loading state, analysis results
@@ -100,9 +107,10 @@ class FileManager:
         try:
             self.tab_manager.set_loading()
 
-            
+            analysis = {"file": file_path, "warnings": [], "passed": []}
+
             if self.document_loader and self.template_loader:
-                parsed_doc = self.document_loader.parse_file(file_path)
+                parsed_doc = self.document_loader.parse_content(file_path, content)
 
                 template = self.file_matcher.match(file_path) if self.file_matcher else None
                 if not template:
@@ -118,20 +126,27 @@ class FileManager:
             error_msg = f"Error during analysis: {str(e)}"
             self.tab_manager.set_analysis(error_msg)
 
-    def on_file_saved(self, file_path: str) -> None:
+    def on_file_saved(self, file_path: str, content: Optional[str] = None) -> None:
         """Handle file saved events and re-run analysis for markdown files.
 
         Args:
             file_path: Path to the file that was saved. If it ends with
                 '.md' and is valid, the file will be re-analyzed.
+            content: Optional in-memory content of the active editor.
 
         Returns:
             None. Triggers analysis when appropriate.
         """
         # Validate before analyzing
         if file_path.lower().endswith(tuple(FileConstants.MARKDOWN_EXTENSIONS)) and self.file_helper.validate_file(file_path):
+            file_content = content if content is not None else self.file_helper.read_file(file_path)
+            if file_content is None:
+                self.tab_manager.set_analysis("Cannot analyze - failed to read saved file content.")
+                return
+
             self.current_file_path = file_path
-            self._analyze_current_file(file_path)
+            self.current_file_content = file_content
+            self._analyze_current_file(file_path, file_content)
 
             if self.auto_stager and self.auto_stager.is_available():
                 self.auto_stager.stage_file_delayed(file_path)
@@ -162,10 +177,11 @@ class FileManager:
 
         if saved_file:
             self.current_file_path = saved_file
+            self.current_file_content = content
             self._is_dirty = False
             self.tab_manager.set_active_tab_file(saved_file)
             self.tab_manager.set_tab_dirty(False)
-            self.on_file_saved(saved_file)
+            self.on_file_saved(saved_file, content)
 
     def on_editor_text_changed(self) -> None:
         """Mark current tab dirty when user edits loaded content."""
@@ -198,9 +214,14 @@ class FileManager:
         if not selected_directory:
             return
 
+        markdown_files = self.file_helper.find_markdown_files(
+            directory=selected_directory,
+            recursive=True,
+        )
+
         self.main_window.get_markdown_viewer().populate_explorer(
             selected_directory,
-            tuple(FileConstants.MARKDOWN_EXTENSIONS),
+            markdown_files,
         )
 
     def on_explorer_item_activated(self, item, _column: int) -> None:
@@ -260,4 +281,5 @@ class FileManager:
         if not state:
             return
         self.current_file_path = state.file_path
+        self.current_file_content = self.tab_manager.get_editor_content() if state.file_path else None
         self._is_dirty = state.is_dirty

--- a/application/ui/components/md_scene.py
+++ b/application/ui/components/md_scene.py
@@ -2,7 +2,7 @@
 Markdown scene.
 """
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Iterable
 
 from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QTabWidget, QPushButton, QCheckBox, QSpacerItem, QSizePolicy, QLabel, QTreeWidget, QSplitter)
 from PyQt6.QtCore import Qt
@@ -98,25 +98,22 @@ class MarkdownScene(QWidget):
         self.main_splitter.addWidget(self.md_editor_widget)
         self.main_splitter.setSizes([UIConstants.FILE_EXPLORER_INIT_WIDTH, UIConstants.FILE_EXPLORER_INIT_HEIGHT])
 
-    def populate_explorer(self, root_directory: str, markdown_extensions: Tuple[str, ...]) -> int:
-        """Populate explorer tree with markdown files from a directory."""
+    def populate_explorer(self, root_directory: str, markdown_file_paths: Iterable[str]) -> int:
+        """Populate explorer tree from markdown file paths provided by FileManager."""
         root_path = Path(root_directory)
         self.file_tree_widget.clear()
-
-        if not root_path.exists() or not root_path.is_dir():
-            return 0
 
         folder_items: Dict[str, QTreeWidgetItem] = {}
         markdown_files_count = 0
 
-        for file_path in sorted(root_path.rglob("*")):
-            if not file_path.is_file():
+        for file_path in sorted(markdown_file_paths):
+            path_obj = Path(file_path)
+
+            try:
+                relative_parts = path_obj.relative_to(root_path).parts
+            except ValueError:
                 continue
 
-            if file_path.suffix.lower() not in markdown_extensions:
-                continue
-
-            relative_parts = file_path.relative_to(root_path).parts
             parent_item = self.file_tree_widget.invisibleRootItem()
             partial_folder = ""
 
@@ -130,7 +127,7 @@ class MarkdownScene(QWidget):
                 parent_item = folder_items[partial_folder]
 
             file_item = QTreeWidgetItem([relative_parts[-1]])
-            file_item.setData(0, Qt.ItemDataRole.UserRole, str(file_path))
+            file_item.setData(0, Qt.ItemDataRole.UserRole, str(path_obj))
             parent_item.addChild(file_item)
             markdown_files_count += 1
 

--- a/application/utils/file_helper.py
+++ b/application/utils/file_helper.py
@@ -193,13 +193,13 @@ class FileHelper:
             return []
         
         try:
-            if recursive:
-                pattern = f"**/*{FileConstants.MARKDOWN_EXTENSIONS[0]}"
-            else:
-                pattern = f"*{FileConstants.MARKDOWN_EXTENSIONS[0]}"
-            
-            md_files = list(search_dir.glob(pattern))
-            return [str(f.resolve()) for f in md_files if f.is_file()]
+            markdown_files = []
+            for extension in FileConstants.MARKDOWN_EXTENSIONS:
+                pattern = f"**/*{extension}" if recursive else f"*{extension}"
+                markdown_files.extend(search_dir.glob(pattern))
+
+            unique_files = {f.resolve() for f in markdown_files if f.is_file()}
+            return [str(file_path) for file_path in sorted(unique_files)]
         
         except (OSError, ValueError) as e:
             import logging

--- a/application/utils/markdown_analyzer.py
+++ b/application/utils/markdown_analyzer.py
@@ -451,8 +451,7 @@ class MarkdownAnalyzer:
         """Generate a human-readable report of the analysis.
 
         Args:
-            analysis: Dict as returned by analyze_markdown_file, optionally
-                      extended with a 'structure_results' key from validate_structure.
+            analysis: Dict returned by validate_structure.
 
         Returns:
             Formatted markdown report string.
@@ -466,12 +465,14 @@ class MarkdownAnalyzer:
         report = "# Markdown Analysis Report\n\n"
 
         if analysis:
+            warnings = analysis.get("warnings", [])
+            passed = analysis.get("passed", [])
             report += "## Structural Validation\n"
-            for warn in analysis["warnings"]:
+            for warn in warnings:
                 report += f"{ReportConstants.ICON_WARNING} (line {warn['line']}): {warn['msg']}\n"
-            for msg in analysis["passed"]:
+            for msg in passed:
                 report += f"{ReportConstants.ICON_OK} {msg}\n"
-            if not analysis["warnings"] and not analysis["passed"]:
+            if not warnings and not passed:
                 report += "No checks were performed.\n"
             report += "\n"
 

--- a/application/utils/markdown_parser.py
+++ b/application/utils/markdown_parser.py
@@ -276,9 +276,25 @@ class MarkdownParser:
         content = self._file_helper.read_file(filepath)
         if content is None:
             raise FileNotFoundError(f"Document not found: {filepath}")
-        doc = self._parse(filepath, content)
+        doc = self.parse_content(filepath, content)
         logger.debug("Loaded document: %s  (%d heading(s))", filepath, len(doc.headings))
         return doc
+
+    def parse_content(self, filepath: str, content: str) -> ParsedDocument:
+        """Parse a single Markdown document from in-memory content.
+
+        Args:
+            filepath (str): Source path used for metadata and diagnostics.
+            content (str): Full markdown text.
+
+        Returns:
+            ParsedDocument: Parsed representation of the content.
+        """
+        if not isinstance(content, str):
+            raise TypeError("content must be a string")
+
+        normalized_path = os.path.abspath(filepath)
+        return self._parse(normalized_path, content)
 
     def parse_dir(self) -> Dict[str, ParsedDocument]:
         """Parse every .md file in directory recursively.


### PR DESCRIPTION
- Added parse_content(filepath, content) to MarkdownParser so parser can parse in-memory text.
- Kept parse_file(filepath) for compatibility with parse_dir(), which currently does nothing.
- Updated FileManager to pass already-read content into parser (parse_content) for active/open document analysis.
- Save flow also reuses editor content for analysis, avoiding a second read for the active doc.
- Analyzer got a small cleanup: report docs now match validate_structure output, and report generation is more defensive.